### PR TITLE
Fix metric naming for fifo queues.

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,8 @@ docker build --tag sqs-exporter  .
 ### Configuration
 AWS credentials can be provided via the following:
 
+Based on [jmal98/sqs-exporter](https://hub.docker.com/r/jmal98/sqs-exporter/)
+
 * Environment Variables - AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY
 * Credentials delivered through the Amazon EC2 container service if AWS_CONTAINER_CREDENTIALS_RELATIVE_URI" environment variable is set and security manager has permission to access the variable,
 * Instance profile credentials delivered through the Amazon EC2 metadata service if running within AWS
@@ -31,22 +33,22 @@ By default, the exporter will watch all SQS queues visible to the AWS account. T
 
 ## Docker
 
-You can deploy this exporter using the [jmal98/sqs-exporter](https://hub.docker.com/r/jmal98/sqs-exporter/) Docker image.
+You can deploy this exporter using the [peopleperhour/sqs-exporter](https://hub.docker.com/r/peopleperhour/sqs-exporter/) Docker image.
 
 If you run in AWS, the following will assume it's running with an IAM profile which will allow read access to SQS information.
 
 ```bash
-docker run -d -p 9384:9384 jmal98/sqs-exporter:0.0.6
+docker run -d -p 9384:9384 peopleperhour/sqs-exporter:promV2
 ```
 
 Use the following to pass the queue filtering environment variables to the docker container.
 
 ```bash
-docker run -d -e SQS_QUEUE_NAME_PREFIX='example_queue_prefix' -p 9384:9384 jmal98/sqs-exporter:0.0.6
+docker run -d -e SQS_QUEUE_NAME_PREFIX='example_queue_prefix' -p 9384:9384 peopleperhour/sqs-exporter:promV2
 ```
 
 If you would like to run the exporter with supplied environment configuration, the following will work both inside and outside of AWS.  This is useful if you desire to run the exporter externally.
 
 ```bash
-docker run -d -p 9384:9384 -e AWS_ACCESS_KEY_ID=<access key> -e AWS_SECRET_ACCESS_KEY=<secret key> -e AWS_REGION=<region>  jmal98/sqs-exporter:0.0.6
+docker run -d -p 9384:9384 -e AWS_ACCESS_KEY_ID=<access key> -e AWS_SECRET_ACCESS_KEY=<secret key> -e AWS_REGION=<region>  peopleperhour/sqs-exporter:promV2
 ```

--- a/src/main/java/org/jmal98/metrics/collector/Sqs.java
+++ b/src/main/java/org/jmal98/metrics/collector/Sqs.java
@@ -65,13 +65,14 @@ public class Sqs extends Collector {
 			for (String qUrl : queueUrls) {
 				String[] tokens = qUrl.split("\\/");
 				String queueName = tokens[tokens.length - 1];
+				String trimmedQueueName = queueName.replace(".fifo", "");
 
 				GetQueueAttributesResult attr = sqs.getQueueAttributes(qUrl, attributeNames);
 				Map<String, String> qAttributes = attr.getAttributes();
 
 				for (String key : qAttributes.keySet()) {
 					GaugeMetricFamily labeledGauge = new GaugeMetricFamily(
-							String.format(queueName+"_sqs_%s", key.toLowerCase().trim()),
+							String.format(trimmedQueueName+"_sqs_%s", key.toLowerCase().trim()),
 							attributeDescriptions.get(key),
 							Arrays.asList("queue"));
 					


### PR DESCRIPTION
Remove .fifo extension from name of metric because this creates an invalid metric name and breaks prometheus monitor.

/cc @tomfotherby @smavroud